### PR TITLE
Add feature(generator_trait) to doc example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! # Example usage
 //! ```
+//! # #![cfg_attr(has_generator_trait, feature(generator_trait))]
 //! use frenetic::{Coroutine, Generator, GeneratorState};
 //! use core::pin::Pin;
 //!


### PR DESCRIPTION
Otherwise the doc test fails with:
```
$ cargo +nightly test --doc
[…]

running 1 test
test src/lib.rs -  (line 6) ... FAILED

failures:

---- src/lib.rs -  (line 6) stdout ----
error[E0658]: use of unstable library feature 'generator_trait'
  --> src/lib.rs:21:5
   |
18 |     GeneratorState::Yielded(1) => {}
   |     ^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: for more information, see https://github.com/rust-lang/rust/issues/43122
   = help: add `#![feature(generator_trait)]` to the crate attributes to enable
[…]
```