### PR TITLE
Add rustfmt check to Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,8 @@ install:
     VOLUME /tmp/build
     WORKDIR /tmp/build
     CMD \$X/cargo build --verbose && \$X/cargo test --verbose && \$X/cargo fmt -- --check
+  - rustup component add rustfmt
 
 script:
+  - cargo fmt -- --check
   - docker run -it --rm -v `pwd`:/tmp/build $TRAVIS_COMMIT


### PR DESCRIPTION
To enforce proper formatting standards on Enarx projects, we'd like to run cargo fmt on all incoming pull requests to Enarx projects. This enables the appropriate test using Travis CI.

Resolves #39.