### PR TITLE
check if stack grows up or down and correct alignment

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -29,6 +29,20 @@ fn main() {
     if probe("#![feature(generator_trait)] fn main() {}") {
         println!("cargo:rustc-cfg=has_generator_trait");
     }
+
+    if probe(
+        r#"
+    extern "C" {
+        fn stk_grows_up(c: *mut c_void) -> bool;
+    }
+    fn main() {
+        let mut test_ptr = true;
+        assert!(stk_grows_up(&mut test_ptr as *mut _ as _));
+    }
+    "#,
+    ) {
+        println!("cargo:rustc-cfg=stk_grows_up");
+    }
 }
 
 /// Test if a code snippet can be compiled

--- a/src/jump.ll
+++ b/src/jump.ll
@@ -81,3 +81,12 @@ next:                                         ; setjmp(%buff) returned 0
 done:                                         ; setjmp(%buff) returned !0
   ret void
 }
+
+define dso_local zeroext i1 @stk_grows_up(i8*) noinline nounwind {
+  %2 = alloca i8*, align 8
+  store i8* %0, i8** %2, align 8
+  %3 = load i8*, i8** %2, align 8
+  %4 = bitcast i8** %2 to i8*
+  %5 = icmp ult i8* %3, %4
+  ret i1 %5
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,8 +230,13 @@ impl<'a, Y, R> Coroutine<'a, Y, R> {
 
         unsafe {
             // Calculate the aligned top of the stack.
-            let top = stack.as_mut_ptr().add(stack.len());
-            let top = top.sub(top.align_offset(STACK_ALIGNMENT));
+            let top = if cfg!(stk_grows_up) {
+                let top = stack.as_mut_ptr();
+                top.add(top.align_offset(STACK_ALIGNMENT))
+            } else {
+                let top = stack.as_mut_ptr().add(stack.len()).sub(STACK_ALIGNMENT);
+                top.add(top.align_offset(STACK_ALIGNMENT))
+            };
 
             // Call into the callback on the specified stack.
             jump_init(


### PR DESCRIPTION
Set `rustc-cfg=stk_grows_up`, if stack grows up determined by build.rs.

Correct stack alignment calculation if stack grows **down**:
- previously align_offset(STACK_ALIGNMENT) was substracted, which is
wrong, because the documentation states:
   > Computes the offset that needs to be applied to the pointer in order to make it aligned to align.
- this patch first substracts STACK_ALIGNMENT and then adds align_offset(STACK_ALIGNMENT)