### PR TITLE
Stackrestore

### DIFF
--- a/src/jump.ll
+++ b/src/jump.ll
@@ -1,39 +1,38 @@
-declare void @llvm.eh.sjlj.longjmp(i8*)
-declare i32 @llvm.eh.sjlj.setjmp(i8*)
-declare void @llvm.stackrestore(i8*)
-declare i8* @llvm.frameaddress(i32)
-declare i8* @llvm.stacksave()
+declare void @llvm.eh.sjlj.longjmp(i8*) noreturn nounwind
+declare i32 @llvm.eh.sjlj.setjmp(i8*) nounwind
+declare void @llvm.stackrestore(i8*) nounwind
+declare i8* @llvm.frameaddress(i32) nounwind readnone
+declare i8* @llvm.stacksave() nounwind
 
-; This function is essentially what __builtin_setjmp() emits in C.
 ; We put it here and mark it as alwaysinline for code-reuse.
 ; This function is internal only.
 define private i32
-@jump_save(i8** nonnull %ctx)
-alwaysinline nounwind naked
+@jump_save([5 x i8*]* nonnull %ctx)
+alwaysinline nounwind naked returns_twice
 {
   ; Store the frame address.
   %frame = call i8* @llvm.frameaddress(i32 0)
-  %foff = getelementptr inbounds i8*, i8** %ctx, i32 0
+  %foff = getelementptr inbounds [5 x i8*], [5 x i8*]* %ctx, i64 0, i32 0
   store i8* %frame, i8** %foff
 
   ; Store the stack address.
   %stack = call i8* @llvm.stacksave()
-  %soff = getelementptr inbounds i8*, i8** %ctx, i32 2
+  %soff = getelementptr inbounds [5 x i8*], [5 x i8*]* %ctx, i64 0, i32 2
   store i8* %stack, i8** %soff
 
   ; The rest are architecture specific and stored by setjmp().
-  %buff = bitcast i8** %ctx to i8*
-  %retv = call i32 @llvm.eh.sjlj.setjmp(i8* %buff)
+  %buff = bitcast [5 x i8*]* %ctx to i8*
+  %retv = call i32 @llvm.eh.sjlj.setjmp(i8* %buff) returns_twice
   ret i32 %retv
 }
 
 ; This function is essentially what __builtin_longjmp() emits in C.
 ; The purpose is to expose this intrinsic to Rust (without requiring nightly).
 define dso_local void
-@jump_into(i8** %into)
+@jump_into([5 x i8*]* nonnull %into)
 noreturn nounwind naked
 {
-  %buff = bitcast i8** %into to i8*
+  %buff = bitcast [5 x i8*]* %into to i8*
   call void @llvm.eh.sjlj.longjmp(i8* %buff) ; Call longjmp()
   unreachable
 }
@@ -41,15 +40,16 @@ noreturn nounwind naked
 ; This function performs a bidirectional context switch.
 ; It simply calls setjmp(%from) and then longjmp(%into).
 define dso_local void
-@jump_swap(i8** %from, i8** %into)
+@jump_swap([5 x i8*]* nonnull %from, [5 x i8*]* nonnull %into)
 nounwind
 {
-  %retv = call i32 @jump_save(i8** %from)    ; setjmp(%from)
+  ; setjmp(%from)
+  %retv = call i32 @jump_save([5 x i8*]* %from) returns_twice
   %zero = icmp eq i32 %retv, 0
   br i1 %zero, label %jump, label %done
 
 jump:                                        ; setjmp(%from) returned 0
-  %ibuf = bitcast i8** %into to i8*
+  %ibuf = bitcast [5 x i8*]* %into to i8*
   call void @llvm.eh.sjlj.longjmp(i8* %ibuf) ; longjmp(%into)
   unreachable
 
@@ -62,20 +62,19 @@ done:                                        ; setjmp(%from) returned !0
 ;   2. Set the stack pointer to %addr.
 ;   3. Call %func(%c, %f).
 define dso_local void
-@jump_init(i8* %addr, i8* %c, i8* %f, void (i8**, i8*, i8*)* %func)
+@jump_init(i8* %addr, i8* %c, i8* %f, void ([5 x i8*]*, i8*, i8*)* %func)
 nounwind
 {
+  %buff = alloca [5 x i8*], align 4          ; Allocate setjmp() buffer
 
-  %buff = alloca [5 x i8*]                    ; Allocate setjmp() buffer
-
-  %cast = bitcast [5 x i8*]* %buff to i8**
-  %retv = call i32 @jump_save(i8** %cast)     ; Call setjmp(%buff)
+  ; Call setjmp(%buff)
+  %retv = call i32 @jump_save([5 x i8*]* %buff) returns_twice
   %zero = icmp eq i32 %retv, 0
   br i1 %zero, label %next, label %done
 
 next:                                         ; setjmp(%buff) returned 0
   call void @llvm.stackrestore(i8* %addr)     ; Move onto new stack %addr
-  call void %func(i8** %cast, i8* %c, i8* %f) ; Call %func(%buff, %c, %f)
+  call void %func([5 x i8*]* %buff, i8* %c, i8* %f) ; Call %func(%buff, %c, %f)
   unreachable
 
 done:                                         ; setjmp(%buff) returned !0

--- a/src/jump.ll
+++ b/src/jump.ll
@@ -73,8 +73,24 @@ nounwind
   br i1 %zero, label %next, label %done
 
 next:                                         ; setjmp(%buff) returned 0
+
+  ; FIXME, the correct solution would be to store those in real registers
+
+  %1 = alloca i8*, align 4
+  %2 = alloca i8*, align 4
+  %3 = alloca void ([5 x i8*]*, i8*, i8*)*, align 4
+
+  store i8* %c, i8** %1
+  store i8* %f, i8** %2
+  store void ([5 x i8*]*, i8*, i8*)* %func, void ([5 x i8*]*, i8*, i8*)** %3
+
   call void @llvm.stackrestore(i8* %addr)     ; Move onto new stack %addr
-  call void %func([5 x i8*]* %buff, i8* %c, i8* %f) ; Call %func(%buff, %c, %f)
+
+  %gc = load i8*, i8** %1
+  %gf = load i8*, i8** %2
+  %gfunc = load void ([5 x i8*]*, i8*, i8*)*, void ([5 x i8*]*, i8*, i8*)** %3
+
+  call void %gfunc([5 x i8*]* %buff, i8* %gc, i8* %gf) ; Call %func(%buff, %c, %f)
   unreachable
 
 done:                                         ; setjmp(%buff) returned !0


### PR DESCRIPTION
Potential fix for the stackrestore problem

By coincindence llvm.stackrestore works on x86. The other architectures
suffer from the compiler not knowing to use the old stackpointer to
load the parameters for %func() and even the value for %func.

The correct handling would be to load those values in registers before
calling llvm.stackrestore and use the to call %func.

This workaround uses alloca to store and load them, which on some
architectures (tested on armv7l) works.

This pull request assumes a merged PR #41 