### PR TITLE
Enable modular test to check nightly features

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,3 +47,13 @@ jobs:
           override: true
       - run: cargo install cargo-readme
       - run: cargo readme > README.md && git diff --exit-code
+
+  check-nightly-features:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: enarx/nightly-features@master
+      with:
+        allowed_features: >
+          asm,
+          naked_functions


### PR DESCRIPTION
This is much like https://github.com/enarx/sev/pull/7. The difference is that this instance should test the case where there _are_ nightly features enabled.